### PR TITLE
Add simple dark mode and speed up extract_title() parsing

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,8 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+    <meta name="color-scheme" content="light dark">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-dark-5@1.1.3/dist/css/bootstrap-dark.min.css" integrity="sha384-pZAJcuaxKZEGkzXV5bYqUcSwBfMZPdQS/+JXdYOu9ScyZJMnGHD5Xi6HVHfZuULH" crossorigin="anonymous">
     <script defer data-domain="wa-law.org" src="https://plausible.io/js/plausible.js"></script>
 
     <title>{{ title }}</title>

--- a/tools/render.py
+++ b/tools/render.py
@@ -37,30 +37,51 @@ def switch_md_to_html(self, tokens, idx, options, env):
 
 md.add_render_rule("link_open", switch_md_to_html)
 
-def extract_title(md_tokens: list, maxsearch: int = 5):
-    title = None
+def extract_title(text: str, path_debug=None, maxlines: int = 3, maxsearch: int = 6):
 
+    # extract top N lines
+    textlines = text.splitlines(keepends=True)
+    top_n_lines = ''.join(textlines[:maxlines])
+
+    # parse top N lines only for title (speeds up parsing considerably)
+    md_tokens = md.parse(top_n_lines)
+
+    # start title search in tokens
+    is_h1 = False
     for token in md_tokens[:maxsearch]:
         tokendict = token.as_dict()
+
+        # h1 text content expected in an h1 inline token with children type 'text'
         try:
-            if tokendict['type'] == 'inline':
-                poss_title = tokendict['children'][0]['content']
-                if len(poss_title) > 1:
-                    # found!
-                    title = poss_title
-                    break
+            # detect h1 open
+            if tokendict['type'] == 'heading_open' and tokendict['tag'] == 'h1':
+                is_h1 = True
+                continue
+
+            # next loop there expect the inline token
+            elif is_h1 and tokendict['type'] == 'inline' and 'children' in tokendict:
+                # look in all children for h1 content
+                for tokenchild in tokendict['children']:
+                    if tokenchild['type'] == 'text':
+                        poss_title = tokenchild['content']
+                        if len(poss_title) > 1:
+                            return poss_title
+
+            else:
+                is_h1 = False
 
         except KeyError:
             warnings.warn('in extract_title, expected token structure failed')
 
-    if title is None:
-        warnings.warn('in extract_title, token was not found')
+    # all tokens exhausted, not found
+    warningmsg = 'title h1 token was not found'
+    if path_debug is not None:
+        warningmsg = warningmsg + ' for: ' + str(path_debug)
+    warnings.warn(warningmsg)
+    return None
 
-    return title
-
-def render(text):
-    mdtokens = md.parse(text)
-    title = extract_title(mdtokens)
+def render(text, path_debug=None):
+    title = extract_title(text, path_debug=path_debug)
     return base_template.render(title=title, body=md.render(text))
 
 ## To export the html to a file, uncomment the lines below:
@@ -78,7 +99,7 @@ if __name__ == "__main__":
             if outpath.name == "README.html":
                 outpath = outpath.with_name("index.html")
             outpath.parent.mkdir(parents=True, exist_ok=True)
-            outpath.write_text(render(subpath.read_text()))
+            outpath.write_text(render(subpath.read_text(), path_debug=subpath))
     else:
         outpath = out / p.with_suffix(".html")
         if outpath.name == "README.html":


### PR DESCRIPTION
1. Addresses #9 by adding <strike>a simple dark mode inline css block</strike> `bootstrap-dark-5` into the `base.html` template.
2. As `md.parse()` for title extraction (from #11) runs almost as slowly as a full `md.render()`, reduce wasted parsing time by only parsing the first N lines (N=3 default) of each `.md` into tokens for subsequent token search.